### PR TITLE
Free memory from FFT setup, samples, window and A.

### DIFF
--- a/Handshake/ToneReceiver.m
+++ b/Handshake/ToneReceiver.m
@@ -159,7 +159,7 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
          }
       }
       
-      NSNumber* toSend = [[NSNumber alloc] initWithInt:maxIndex];
+      NSNumber *toSend = [[NSNumber alloc] initWithInt:maxIndex];
       
       if (self.delegate)
       {
@@ -167,6 +167,12 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
       }
        
       //NSLog(@"Char: %c at %d", (char)(maxIndex - self.baseBin), maxIndex);
+       
+      vDSP_destroy_fftsetup(setup);
+      free(samples);
+      free(window);
+      free(A.imagp);
+      free(A.realp);
    }
 }
 


### PR DESCRIPTION
Hey, Matt! I just free the memory from FFT setup, samples, window and A - it's was causing a memory leak, making the app stop working after some time.
